### PR TITLE
Add Cocoapods public headers to HEADER_SEARCH_PATHS

### DIFF
--- a/ios/RNHeap.xcodeproj/project.pbxproj
+++ b/ios/RNHeap.xcodeproj/project.pbxproj
@@ -219,6 +219,7 @@
 					"$(SRCROOT)/../react-native/React/**",
 					"$(SRCROOT)/node_modules/react-native/React/**",
 					"$(SRCROOT)/../../../node_modules/react-native/React/**",
+					"$(PROJECT_DIR)/../../../ios/Pods/Headers/Public/**",
 				);
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -240,6 +241,7 @@
 					"$(SRCROOT)/../react-native/React/**",
 					"$(SRCROOT)/node_modules/react-native/React/**",
 					"$(SRCROOT)/../../../node_modules/react-native/React/**",
+					"$(PROJECT_DIR)/../../../ios/Pods/Headers/Public/**",
 				);
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
Added Pods/Headers/Public/** to the HEADER_SEARCH_PATHS to resolve
resolution issues when integrating with Heap as a Pod but directly
bundling react-native-heap-analytics in the project.